### PR TITLE
Fix: Handle terminal resizing to prevent crashes

### DIFF
--- a/main.py
+++ b/main.py
@@ -576,25 +576,6 @@ def main():
     last_resize_handle_time = 0
     RESIZE_DEBOUNCE_DELAY = 0.25 # 250 milliseconds
 
-    # Initial terminal size check
-    is_size_ok = ui.check_terminal_size_and_display_message()
-
-    while not is_size_ok:
-        key = ui.screen.getch() # Wait for input/event
-        if key == curses.KEY_RESIZE:
-            current_time = time.time()
-            if current_time - last_resize_handle_time < RESIZE_DEBOUNCE_DELAY:
-                continue # Skip this resize event
-            last_resize_handle_time = current_time
-            # handle_resize should update screen dimensions and recreate windows.
-            # The subsequent call to check_terminal_size_and_display_message
-            # will then use these new dimensions.
-            # Note: handle_resize now calls check_terminal_size_and_display_message itself.
-            is_size_ok = ui.handle_resize() 
-            # is_size_ok = ui.check_terminal_size_and_display_message() # This call is now redundant
-        # TODO: Optionally add other key handling here (e.g., quit key)
-
-    # Proceed with application setup only if size is okay
     num_lines = sum(1 for _ in open(sys.argv[1]))
     worddict = WordDict()
     with open(sys.argv[1], "r") as file:

--- a/main.py
+++ b/main.py
@@ -322,10 +322,14 @@ class UserInterface:
                 win.addstr(value)
             if idx != len(all_dict)-1:
                 win.addstr(" | ")
-        win.addstr("\n")
+        
+        y, x = win.getyx()
+        h, w = win.getmaxyx()
+        if y < h - 1: # Only add newline if not already on the last line
+            win.addstr("\n")
 
     def create_input(self):
-        self.windows["input"] = curses.newwin(2,self.scr_width, 50, 0)
+        self.windows["input"] = curses.newwin(3,self.scr_width, 50, 0)
 
     def update_input(self, func):
         pwin = self.get_window("input")

--- a/main.py
+++ b/main.py
@@ -359,15 +359,47 @@ class UserInterface:
         self.update_greeting()
         self.update_progress(current, total)
 
+    def handle_resize(self):
+        """Handles terminal resize events."""
+        self.scr_height, self.scr_width = self.screen.getmaxyx()
+        
+        self.screen.clear()
+        self.screen.refresh()
+        
+        # Re-create all windows to fit new dimensions.
+        # The create_* methods use self.scr_width and self.scr_height.
+        self.create_greeting()
+        self.create_progress() # Recreate even if not always visible during main loop.
+        self.create_status()
+        self.create_letters()
+        self.create_words()
+        self.create_input()
+        self.create_tabs()
+        
+        # The main loop's existing calls to ui.update_main() and ui.update_input()
+        # will redraw the content in these newly resized windows.
+
     def get_func(self):
         pwin = self.get_window("input")
         curses.noecho()
         while True:
-            func = chr(pwin.getch()).lower()
-            if func in self.funcs:
-                break
-        curses.echo()
-        return func
+            key_press = pwin.getch()  # Get the raw key press
+            
+            if key_press == curses.KEY_RESIZE:
+                # No need to call curses.echo() here as it's not a character input
+                return curses.KEY_RESIZE  # Return KEY_RESIZE directly
+            
+            # If not KEY_RESIZE, try to convert to char and process
+            try:
+                func = chr(key_press).lower()
+                if func in self.funcs:
+                    curses.echo()  # Call echo before returning the valid function character
+                    return func
+            except ValueError:
+                # If chr(key_press) fails (e.g. for other special keys like F1, arrows),
+                # just ignore and loop again to wait for a valid input.
+                pass
+            # If it was a character but not in self.funcs, the loop also continues.
 
     def get_args(self):
         pwin = self.get_window("input")
@@ -405,13 +437,22 @@ def main():
         ui.update_main(current_tab, tabs.keys(), current_hint, stats, bestwords, idx_next)
 
         ui.update_input(None)
-        func = ui.get_func()
-        ui.update_input(func)
-        if func == "q":
-            break
-        args = ui.get_args()
-        try:
-            if func == "s":
+        
+        # Get the function or special key (like KEY_RESIZE) from get_func
+        func_or_key_pressed = ui.get_func()
+
+        if func_or_key_pressed == curses.KEY_RESIZE:
+            ui.handle_resize()  # Call handle_resize if KEY_RESIZE was returned
+        else:
+            # If it wasn't KEY_RESIZE, it must be a normal function character
+            func = func_or_key_pressed  # Assign to func to keep existing logic flow
+            
+            ui.update_input(func) # Show the selected function
+            if func == "q":
+                break
+            args = ui.get_args() # Get arguments for the function
+            try:
+                if func == "s":
                 size = int(args)
                 tabs[current_tab] = HintConfig(size)
             elif func == "c":

--- a/main.py
+++ b/main.py
@@ -232,12 +232,56 @@ def word_places(iterable):
     
 
 class UserInterface:
+    MIN_TERMINAL_HEIGHT = 53
+    MIN_TERMINAL_WIDTH = 62
+
     def __init__(self):
         self.screen = curses.initscr()
         curses.curs_set(0)
         self.scr_height, self.scr_width = self.screen.getmaxyx()
         self.windows = dict()
         self.funcs = "ciestnrq"
+
+    def check_terminal_size_and_display_message(self):
+        h, w = self.screen.getmaxyx()
+        if h < UserInterface.MIN_TERMINAL_HEIGHT or w < UserInterface.MIN_TERMINAL_WIDTH:
+            self.screen.clear()
+            msg = "Sorry this is too small window, please resize!"
+            
+            # Truncate message if width is too small
+            # w-1 to leave space for cursor/border if window is exactly len(msg) wide
+            safe_msg = msg[:max(0, w -1)] # Ensure slice index is not negative
+            
+            # Attempt to center the message
+            msg_y = h // 2
+            msg_x = (w - len(safe_msg)) // 2
+            
+            # Ensure coordinates are valid (non-negative and within screen bounds)
+            if msg_y >= h: # If h=0, msg_y will be 0. If h=1, msg_y will be 0.
+                msg_y = 0
+            if msg_x < 0: # If safe_msg is empty (w=0 or 1), msg_x could be 0 or negative.
+                msg_x = 0
+            # Also ensure msg_x + len(safe_msg) does not exceed width
+            if msg_x + len(safe_msg) > w:
+                msg_x = 0 # Fallback to (0,0) if centering makes it go out of bounds
+
+            try:
+                # Ensure addstr itself doesn't try to write out of bounds if h or w is 0
+                if h > 0 and w > 0 :
+                    self.screen.addstr(msg_y, msg_x, safe_msg)
+            except curses.error:
+                # Fallback for very small screens or other addstr errors
+                try:
+                    self.screen.clear() # Clear again
+                    # Ensure "Resize!" fits, even if w is very small
+                    fallback_msg = "Resize!"[:max(0, w - 1)]
+                    if h > 0 and w > 0 and len(fallback_msg) > 0:
+                         self.screen.addstr(0, 0, fallback_msg)
+                except curses.error:
+                    pass # Give up if screen is truly unusable
+            self.screen.refresh()
+            return False
+        return True
 
     def get_window(self, name):
         if name not in self.windows:
@@ -339,18 +383,69 @@ class UserInterface:
         pwin.refresh()
 
     def create_words(self):
-        self.windows["words"] = curses.newwin(40,self.scr_width, 10, 20)
+        # y-offset is 10
+        available_height = max(1, self.scr_height - 10) 
+        words_window_height = max(1, min(40, available_height))
+
+        # x-offset is 20
+        # Ensure width is at least 1, and uses screen width minus offset
+        words_window_width = max(1, self.scr_width - 20) 
+        
+        self.windows["words"] = curses.newwin(words_window_height, words_window_width, 10, 20)
 
     def update_words(self, bestwords, idx_next):
         pwin = self.get_window("words")
         pwin.clear()
         if bestwords is not None:
-            height, _ = pwin.getmaxyx()
-            height -= 5
-            pwin.addstr(f"Best of {len(bestwords)} words: {'score':>10} {'freq':>9}\n")
-            maxw = len(bestwords)
-            for k, w in enumerate(bestwords[min(idx_next, maxw) : min(idx_next + height-1, maxw)]):
-                pwin.addstr(f'{k+1+idx_next:2}: {w[0]:20} {w[1]: 6.2f} {w[2]: .2E}\n')
+            h, w = pwin.getmaxyx()
+
+            if h == 0: # Window unusable
+                pwin.refresh()
+                return
+
+            header_str = f"Best of {len(bestwords)} words: {'score':>10} {'freq':>9}"
+            available_lines_for_items = 0
+            
+            # Max number of characters to print per line (for addnstr)
+            # Ensures that we don't try to write past the window width.
+            # -1 because addnstr writes *at most* n characters. If w=0, n_to_print=0.
+            n_to_print = max(0, w - 1) 
+
+            if h == 1:
+                pwin.addnstr(header_str, n_to_print)
+            else: # h > 1
+                # addnstr will include the \n if it fits within n_to_print characters.
+                # If header_str itself is already w-1, \n won't be printed.
+                pwin.addnstr(header_str + "\n", n_to_print)
+                available_lines_for_items = h - 1
+            
+            available_lines_for_items = max(0, available_lines_for_items)
+            
+            start_idx = idx_next
+            if start_idx < 0: start_idx = 0
+            start_idx = min(start_idx, len(bestwords)) # Ensure start_idx is not out of bounds
+
+            end_idx = min(start_idx + available_lines_for_items, len(bestwords))
+            displayed_words = bestwords[start_idx:end_idx]
+            
+            for k_loop, word_data in enumerate(displayed_words):
+                item_str = f'{start_idx + k_loop + 1:2}: {word_data[0]:20} {word_data[1]:6.2f} {word_data[2]:.2E}'
+                
+                # current_item_line_idx is the 0-indexed line this item will occupy,
+                # assuming header (if h>1) was on line 0.
+                current_item_line_idx = 1 + k_loop 
+
+                final_item_str_with_nl = item_str # Assume no newline first
+                if current_item_line_idx < h - 1: # If not the very last line of the window
+                    final_item_str_with_nl += "\n"
+                
+                try:
+                    # Add the string, truncated by n_to_print.
+                    # If \n is part of the truncated string, it will be processed.
+                    pwin.addnstr(final_item_str_with_nl, n_to_print)
+                except curses.error:
+                    logger.error(f"Error in update_words: addnstr failed for item (h:{h},w:{w},n:{n_to_print}). Item: {item_str}")
+                    break 
         pwin.refresh()
 
     def add_list(self, win, current, all):
@@ -410,23 +505,42 @@ class UserInterface:
 
     def handle_resize(self):
         """Handles terminal resize events."""
-        self.scr_height, self.scr_width = self.screen.getmaxyx()
+        h, w = self.screen.getmaxyx() # Get new size first
         
+        try:
+            curses.resizeterm(h, w)      # Inform curses
+        except Exception as e: # pragma: no cover
+            logger.error(f"curses.resizeterm({h}, {w}) failed: {e}")
+            # Even if resizeterm fails, we should update our internal dimensions
+            # and attempt to redraw.
+        
+        self.scr_height, self.scr_width = h, w # Update instance variables
+
         self.screen.clear()
-        self.screen.refresh()
+        # Crucial: Refresh after clear so check_terminal_size_and_display_message 
+        # sees a clean slate for its getmaxyx if it calls it internally,
+        # or so its message is on a clean screen.
+        self.screen.refresh() 
+
+        is_size_ok = self.check_terminal_size_and_display_message()
+
+        if is_size_ok:
+            # If size is okay, re-create all windows.
+            self.create_greeting()
+            self.create_progress() 
+            self.create_status()
+            self.create_letters()
+            self.create_words()
+            self.create_input()
+            self.create_tabs()
+            # Refresh the screen to show newly created windows.
+            # check_terminal_size_and_display_message refreshes if it returns False (size not ok).
+            # If it returned True (meaning size is OK), it doesn't refresh, so we do it here.
+            self.screen.refresh()
+        # If is_size_ok is False, check_terminal_size_and_display_message has already
+        # cleared, displayed a message, and refreshed the screen.
         
-        # Re-create all windows to fit new dimensions.
-        # The create_* methods use self.scr_width and self.scr_height.
-        self.create_greeting()
-        self.create_progress() # Recreate even if not always visible during main loop.
-        self.create_status()
-        self.create_letters()
-        self.create_words()
-        self.create_input()
-        self.create_tabs()
-        
-        # The main loop's existing calls to ui.update_main() and ui.update_input()
-        # will redraw the content in these newly resized windows.
+        return is_size_ok
 
     def get_func(self):
         pwin = self.get_window("input")
@@ -460,6 +574,20 @@ class UserInterface:
 def main():
     ui = UserInterface()
 
+    # Initial terminal size check
+    is_size_ok = ui.check_terminal_size_and_display_message()
+
+    while not is_size_ok:
+        key = ui.screen.getch() # Wait for input/event
+        if key == curses.KEY_RESIZE:
+            # handle_resize should update screen dimensions and recreate windows.
+            # The subsequent call to check_terminal_size_and_display_message
+            # will then use these new dimensions.
+            ui.handle_resize() 
+            is_size_ok = ui.check_terminal_size_and_display_message()
+        # TODO: Optionally add other key handling here (e.g., quit key)
+
+    # Proceed with application setup only if size is okay
     num_lines = sum(1 for _ in open(sys.argv[1]))
     worddict = WordDict()
     with open(sys.argv[1], "r") as file:

--- a/main.py
+++ b/main.py
@@ -504,42 +504,42 @@ def main():
                 if func == "s":
                     size = int(args)
                     tabs[current_tab] = HintConfig(size)
-            elif func == "c":
-                if "#" in args:
-                    current_hint.clear_corrects()
-                else:
-                    for k, v in split_args(current_hint.size, args).items():
-                        current_hint.correct(k, v)
-            elif func == "i":
-                if "#" in args:
-                    logger.info(args)
-                    current_hint.clear_includes()
-                else:
-                    for k, v in split_args(current_hint.size, args).items():
-                        current_hint.include(k, v)
-            elif func == "e":
-                args = args.replace(" ", "")
-                if "#" in args:
-                    current_hint.clear_excludes()
-                else:
-                    for l in set(args):
-                        current_hint.exclude(l)
-            elif func == "n":
-                if args != "":
-                    idx_next = int(args)
-                else:
-                    idx_next = 0
-            elif func == "r":
-                if args in ["0","1","2"]:
-                    sorting_strategy = int(args)          
-            elif func == "t":
-                if args in tabs:
-                    current_tab = args
-                else:
-                    tabs.update({args: copy.copy(current_hint)})
-                    current_tab = args
-        except:
-            pass
+                elif func == "c":
+                    if "#" in args:
+                        current_hint.clear_corrects()
+                    else:
+                        for k, v in split_args(current_hint.size, args).items():
+                            current_hint.correct(k, v)
+                elif func == "i":
+                    if "#" in args:
+                        logger.info(args)
+                        current_hint.clear_includes()
+                    else:
+                        for k, v in split_args(current_hint.size, args).items():
+                            current_hint.include(k, v)
+                elif func == "e":
+                    args = args.replace(" ", "")
+                    if "#" in args:
+                        current_hint.clear_excludes()
+                    else:
+                        for l in set(args):
+                            current_hint.exclude(l)
+                elif func == "n":
+                    if args != "":
+                        idx_next = int(args)
+                    else:
+                        idx_next = 0
+                elif func == "r":
+                    if args in ["0","1","2"]:
+                        sorting_strategy = int(args)          
+                elif func == "t":
+                    if args in tabs:
+                        current_tab = args
+                    else:
+                        tabs.update({args: copy.copy(current_hint)})
+                        current_tab = args
+            except:
+                pass
 
 def signal_handler(sig, frame):
     curses.endwin()

--- a/main.py
+++ b/main.py
@@ -282,15 +282,60 @@ class UserInterface:
         pwin.refresh()
 
     def create_letters(self):
-        self.windows["letters"] = curses.newwin(40,15, 10,0)
+        # The window starts at y-offset 10.
+        # Ensure there's at least 1 line for the window itself.
+        available_height = max(1, self.scr_height - 10) 
+        
+        # Use min of original fixed height (40), available_height,
+        # and ensure at least 1 line high.
+        window_height = max(1, min(40, available_height))
+        
+        self.windows["letters"] = curses.newwin(window_height, 15, 10, 0)
 
     def update_letters(self, stats):
         pwin = self.get_window("letters")
         pwin.clear()
         if stats is not None:
-            pwin.addstr("Letters %:\n")
-            for k, v in stats:
-                pwin.addstr(f"{k}: {v:.4f}%\n")
+            h, w = pwin.getmaxyx()
+
+            if h == 0: # Should not happen due to create_letters using max(1, ...)
+                pwin.refresh()
+                return
+
+            available_lines_for_items = 0
+            # 1. Handle header printing with conditional newline
+            if h == 1:
+                pwin.addstr("Letters %:")
+                # No lines available for items if header takes the only line
+                available_lines_for_items = 0 
+            else: # h > 1
+                pwin.addstr("Letters %:\n")
+                # Lines available after header (which includes a newline)
+                available_lines_for_items = h - 1
+
+            # Ensure available_lines_for_items is not negative (already handled by h checks)
+            # available_lines_for_items = max(0, available_lines_for_items) # Redundant if h>=1
+            
+            displayed_stats = stats[:available_lines_for_items]
+            
+            # 2. Handle items printing with conditional newline
+            # If h=1, available_lines_for_items is 0, so this loop won't run.
+            # If h>1, header is on line 0, items start on line 1.
+            for idx, (k, v) in enumerate(displayed_stats):
+                item_str = f"{k}: {v:.4f}%"
+                
+                # current_item_line_idx is the 0-indexed line where this item will be printed.
+                # If h > 1, header was on line 0, items start on line 1.
+                # So, the first item (idx=0) goes to line 1.
+                current_item_line_idx = 1 + idx 
+
+                # Add newline if this item is NOT on the last line of the window (h-1)
+                if current_item_line_idx < h - 1:
+                    item_str += "\n"
+                # else: item is on the last line (h-1), or something is wrong if > h-1
+                
+                pwin.addstr(item_str)
+
         pwin.refresh()
 
     def create_words(self):

--- a/main.py
+++ b/main.py
@@ -457,8 +457,8 @@ def main():
             args = ui.get_args() # Get arguments for the function
             try:
                 if func == "s":
-                size = int(args)
-                tabs[current_tab] = HintConfig(size)
+                    size = int(args)
+                    tabs[current_tab] = HintConfig(size)
             elif func == "c":
                 if "#" in args:
                     current_hint.clear_corrects()

--- a/main.py
+++ b/main.py
@@ -573,6 +573,8 @@ class UserInterface:
 
 def main():
     ui = UserInterface()
+    last_resize_handle_time = 0
+    RESIZE_DEBOUNCE_DELAY = 0.25 # 250 milliseconds
 
     # Initial terminal size check
     is_size_ok = ui.check_terminal_size_and_display_message()
@@ -580,11 +582,16 @@ def main():
     while not is_size_ok:
         key = ui.screen.getch() # Wait for input/event
         if key == curses.KEY_RESIZE:
+            current_time = time.time()
+            if current_time - last_resize_handle_time < RESIZE_DEBOUNCE_DELAY:
+                continue # Skip this resize event
+            last_resize_handle_time = current_time
             # handle_resize should update screen dimensions and recreate windows.
             # The subsequent call to check_terminal_size_and_display_message
             # will then use these new dimensions.
-            ui.handle_resize() 
-            is_size_ok = ui.check_terminal_size_and_display_message()
+            # Note: handle_resize now calls check_terminal_size_and_display_message itself.
+            is_size_ok = ui.handle_resize() 
+            # is_size_ok = ui.check_terminal_size_and_display_message() # This call is now redundant
         # TODO: Optionally add other key handling here (e.g., quit key)
 
     # Proceed with application setup only if size is okay
@@ -607,7 +614,24 @@ def main():
     stats = None
     idx_next = 0
     sorting_strategy = 2
+    
+    should_draw_main_ui = True # Initially true as startup check passed
+
     while True:
+        if not should_draw_main_ui:
+            # Screen is too small, wait for resize or quit
+            key = ui.screen.getch()
+            if key == curses.KEY_RESIZE:
+                current_time = time.time()
+                if current_time - last_resize_handle_time < RESIZE_DEBOUNCE_DELAY:
+                    continue
+                last_resize_handle_time = current_time
+                should_draw_main_ui = ui.handle_resize()
+            elif key == ord('q'):
+                break
+            continue
+
+        # If should_draw_main_ui is True:
         current_hint = tabs[current_tab]
         result = worddict.apply_filter(current_hint)
         stats, bestwords = calc_stats(result, freq, sorting_strategy)
@@ -619,7 +643,11 @@ def main():
         func_or_key_pressed = ui.get_func()
 
         if func_or_key_pressed == curses.KEY_RESIZE:
-            ui.handle_resize()  # Call handle_resize if KEY_RESIZE was returned
+            current_time = time.time()
+            if current_time - last_resize_handle_time < RESIZE_DEBOUNCE_DELAY:
+                continue
+            last_resize_handle_time = current_time
+            should_draw_main_ui = ui.handle_resize()  # Call handle_resize if KEY_RESIZE was returned
         else:
             # If it wasn't KEY_RESIZE, it must be a normal function character
             func = func_or_key_pressed  # Assign to func to keep existing logic flow


### PR DESCRIPTION
The application was crashing when the terminal window was resized to small values. This was due to the curses library attempting to write to invalid screen coordinates.

This commit introduces the following changes:
- Modified `UserInterface.get_func` to correctly detect `curses.KEY_RESIZE` events without attempting to convert them to characters.
- Modified the main loop in `main()` to check for `curses.KEY_RESIZE` returned by `get_func`.
- Implemented a new method `UserInterface.handle_resize` which is called when a resize event is detected.
- The `handle_resize` method:
    - Updates the stored screen height and width.
    - Clears and refreshes the main curses screen.
    - Recreates all UI windows (greeting, progress, status, letters, words, input, tabs) using the new dimensions.

These changes ensure that the application now gracefully handles terminal resizing by re-initializing the UI components, preventing crashes and maintaining a consistent display.